### PR TITLE
Use either rst2man or rst2man.py

### DIFF
--- a/doc/gen_docs.sh
+++ b/doc/gen_docs.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
 
 rst2pdf manual.rst --custom-cover=assets/cover.tmpl -o output/pdf/manual.pdf -s assets/manual.style -b1
-rst2man rst2pdf.rst output/rst2pdf.1
+
+# Determine correct name for rst2man
+RST2MAN="rst2man"
+if [ -x "$(command -v rst2man.py)" ]; then
+    RST2MAN="rst2man.py"
+fi
+$RST2MAN rst2pdf.rst output/rst2pdf.1
 
 # set PYTHONPATH so we use the current contents of this repo, rather than our installed rst2pdf
 PYTHONPATH=../ python rst2html-manual.py --stylesheet=assets/manual.css manual.rst output/html/manual.html


### PR DESCRIPTION
If Docutils is installed via pip, then the script name is rst2man.py, however if it is installed via apt or yum, then it is named rst2man. Use `rst2man`, unless we find `rst2man,py`, in which case, use it.