### PR TITLE
Tidy up GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     - name: Lint
       run: |
         pre-commit run --all-files --show-diff-on-failure
+      if: matrix.python-version == '3.8'
     - name: Test with pytest
       run: |
         pytest -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get -y install plantuml
         python -m pip install --upgrade pip
         pip install pytest
         pip install --upgrade setuptools


### PR DESCRIPTION
Update the Action:

* We only need to lint on one of the Pythons. I picked 3.8.
* Install `plantuml` so that `test_uml_extension` is not skipped.
* Enable this action for pull requests too.