### PR TITLE
Use new font name aliases

### DIFF
--- a/rst2pdf/styles/styles.yaml
+++ b/rst2pdf/styles/styles.yaml
@@ -199,10 +199,10 @@ styles:
     parent: bodytext
     spaceBefore: 0
   definition-list-classifier:
-    fontName: stdItalic
+    fontName: fontSansItalic
     parent: normal
   definition-list-term:
-    fontName: stdBold
+    fontName: fontSansBold
     keepWithNext: false
     parent: normal
     spaceAfter: 0
@@ -262,7 +262,7 @@ styles:
     spaceBefore: 6
   fieldname:
     alignment: TA_RIGHT
-    fontName: stdBold
+    fontName: fontSansBold
     parent: bodytext
   fieldvalue:
     parent: bodytext
@@ -286,7 +286,7 @@ styles:
     parent: bodytext
   figure-caption:
     alignment: TA_CENTER
-    fontName: stdItalic
+    fontName: fontSansItalic
     parent: bodytext
   figure-legend:
     parent: bodytext
@@ -330,7 +330,7 @@ styles:
   important-heading:
     parent: admonition-heading
   italic:
-    fontName: stdItalic
+    fontName: fontSansItalic
     parent: bodytext
   item-list:
     colWidths:
@@ -361,7 +361,7 @@ styles:
     parent: code
   literal:
     firstLineIndent: 0
-    fontName: stdMono
+    fontName: fontMono
     hyphenation: false
     parent: normal
     wordWrap: null
@@ -659,7 +659,7 @@ styles:
     parent: heading
     spaceAfter: 36
   title-reference:
-    fontName: stdItalic
+    fontName: fontSansItalic
     parent: normal
   toc:
     parent: normal

--- a/rst2pdf/styles/styles.yaml
+++ b/rst2pdf/styles/styles.yaml
@@ -1,51 +1,41 @@
 embeddedFonts: []
 fontsAlias:
-  stdBold: Helvetica-Bold
-  stdBoldItalic: Helvetica-BoldOblique
-  stdFont: Helvetica
-  stdItalic: Helvetica-Oblique
-  stdMono: Courier
-  stdMonoBold: Courier-Bold
-  stdMonoBoldItalic: Courier-BoldOblique
-  stdMonoItalic: Courier-Oblique
-  stdSans: Helvetica
-  stdSansBold: Helvetica-Bold
-  stdSansBoldItalic: Helvetica-BoldOblique
-  stdSansItalic: Helvetica-Oblique
-  stdSerif: Times-Roman
-linkColor: navy
+  fontSerifBold: Times-Bold
+  fontSerifBoldItalic: Times-BoldItalic
+  fontSerif: Times-Roman
+  fontSerifItalic: Times-Italic
+  fontMono: Courier
+  fontMonoBold: Courier-Bold
+  fontMonoBoldItalic: Courier-BoldOblique
+  fontMonoItalic: Courier-Oblique
+  fontSans: Helvetica
+  fontSansBold: Helvetica-Bold
+  fontSansBoldItalic: Helvetica-BoldOblique
+  fontSansItalic: Helvetica-Oblique
+linkColor: "#006699"
 pageSetup:
-  firstTemplate: oneColumn
+  firstTemplate: mainPage
   height: null
-  margin-bottom: 2cm
+  margin-bottom: 1.5cm
   margin-gutter: 0cm
-  margin-left: 2cm
-  margin-right: 2cm
+  margin-left: 1.8cm
+  margin-right: 1.8cm
   margin-top: 2cm
   size: A4
   spacing-footer: 5mm
   spacing-header: 5mm
   width: null
 pageTemplates:
-  coverPage:
-    frames:
-    - - 0cm
-      - 0cm
-      - 100%
-      - 100%
-    showFooter: false
-    showHeader: false
-  cutePage:
+  mainPage:
     defaultFooter: '###Page###'
-    defaultHeader: '###Section###'
     frames:
     - - 0%
       - 0%
       - 100%
       - 100%
     showFooter: true
-    showHeader: true
-  emptyPage:
+    showHeader: false
+  coverPage:
     frames:
     - - 0cm
       - 0cm
@@ -58,34 +48,6 @@ pageTemplates:
     - - 0cm
       - 0cm
       - 100%
-      - 100%
-    showFooter: true
-    showHeader: true
-  threeColumn:
-    frames:
-    - - 2%
-      - 0cm
-      - 29.333%
-      - 100%
-    - - 35.333%
-      - 0cm
-      - 29.333%
-      - 100%
-    - - 68.666%
-      - 0cm
-      - 29.333%
-      - 100%
-    showFooter: true
-    showHeader: true
-  twoColumn:
-    frames:
-    - - 0cm
-      - 0cm
-      - 49%
-      - 100%
-    - - 51%
-      - 0cm
-      - 49%
       - 100%
     showFooter: true
     showHeader: true
@@ -133,12 +95,12 @@ styles:
     borderPadding: 0
     borderRadius: null
     borderWidth: 0
-    bulletFontName: stdFont
+    bulletFontName: fontMono
     bulletFontSize: 10
     bulletIndent: 0
     commands: []
     firstLineIndent: 0
-    fontName: stdFont
+    fontName: fontSans
     fontSize: 10
     hyphenation: false
     leading: 12
@@ -339,26 +301,22 @@ styles:
     parent: normal
     spaceAfter: 6
     spaceBefore: 12
+    fontName: fontSerif
+    textColor: "#333333"
   heading1:
-    fontName: stdBold
     fontSize: 175%
     parent: heading
   heading2:
-    fontName: stdBold
     fontSize: 150%
     parent: heading
   heading3:
-    fontName: stdBoldItalic
     fontSize: 125%
     parent: heading
   heading4:
-    fontName: stdBoldItalic
     parent: heading
   heading5:
-    fontName: stdBoldItalic
     parent: heading
   heading6:
-    fontName: stdBoldItalic
     parent: heading
   hint:
     parent: admonition
@@ -696,18 +654,17 @@ styles:
     parent: admonition-heading
   title:
     alignment: TA_CENTER
-    fontName: stdBold
     fontSize: 200%
     keepWithNext: false
     parent: heading
-    spaceAfter: 10
+    spaceAfter: 36
   title-reference:
     fontName: stdItalic
     parent: normal
   toc:
     parent: normal
+    fontSize: 85%
   toc1:
-    fontName: stdBold
     parent: toc
   toc10:
     leftIndent: 100

--- a/rst2pdf/styles/twocolumn.yaml
+++ b/rst2pdf/styles/twocolumn.yaml
@@ -2,3 +2,16 @@ pageSetup:
   firstTemplate: twoColumn
   margin-left: 1cm
   margin-right: 1cm
+pageTemplates:
+  twoColumn:
+    frames:
+    - - 0cm
+      - 0cm
+      - 49%
+      - 100%
+    - - 51%
+      - 0cm
+      - 49%
+      - 100%
+    showFooter: true
+    showHeader: true


### PR DESCRIPTION
As the font names are now prefixed `font` rather than `std`, update all cases that still use `std`.